### PR TITLE
Use svgson transformNode instead of custom function

### DIFF
--- a/packages/unicon-transformer-json/package.json
+++ b/packages/unicon-transformer-json/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "dependencies": {
     "svgo": "^1.0.5",
-    "svgson-next": "^4.1.5"
+    "svgson-next": "4.1.6"
   },
   "devDependencies": {
     "prettier": "1.14.2"

--- a/packages/unicon-transformer-json/yarn.lock
+++ b/packages/unicon-transformer-json/yarn.lock
@@ -327,9 +327,9 @@ svgo@^1.0.5:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
-svgson-next@^4.1.5:
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/svgson-next/-/svgson-next-4.1.5.tgz#7eb43d2c98dbe46ee21497165d7ae986c2125be0"
+svgson-next@4.1.6:
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/svgson-next/-/svgson-next-4.1.6.tgz#2729674e14e43ddf4c550fecccf1837bcacd8055"
   dependencies:
     clean-deep "3.0.2"
     deep-rename-keys "^0.2.1"


### PR DESCRIPTION
`transformNode` option from `svgson` does exactly what the custom function _walkChildren_ did, map `children` and apply transformations

Updated `svgson` version due to a bug related to this _option_